### PR TITLE
Pass p parameter explicitly in "character,MgsaSets" function

### DIFF
--- a/R/mgsa-methods.R
+++ b/R/mgsa-methods.R
@@ -290,7 +290,8 @@ setMethod(
 setMethod(
 		f="mgsa",
 		signature = c(o="character", sets="MgsaSets"),
-		def=function( o, sets, population=NULL, ...) {
+		def=function( o, sets, population=NULL, 
+			      p=seq(min(0.1, 1/length(sets)), min(0.3, 20/length(sets)), length.out=10), ...) {
 			
 			items<-itemIndices(sets,o)
 			items.nas<-sum(is.na(items))

--- a/R/mgsa-methods.R
+++ b/R/mgsa-methods.R
@@ -307,12 +307,12 @@ setMethod(
 			{
 				# If no population has been specified, we do not need
 				# to consolidate the set and obervation ids
-				rv = mgsa.wrapper(items, sets@sets, sets@numberOfItems, ...)
+				rv = mgsa.wrapper(items, sets@sets, sets@numberOfItems, p=p, ...)
 			}
 			else
 			{
 				population<-itemIndices(sets,population)
-				rv = mgsa.main( items, sets@sets, population, ...)
+				rv = mgsa.main( items, sets@sets, population, p=p, ...)
 			}
 			rv@setsResults = cbind(setsResults(rv),  setAnnotations(sets)[ rownames(setsResults(rv) ), , drop=FALSE] )
 			return( rv )

--- a/tests/testthat/test-mgsa.R
+++ b/tests/testthat/test-mgsa.R
@@ -62,3 +62,15 @@ test_that("mgsa() works with explict multiple p", {
   expect_equal( pPost(mgsa.result)$value, c(0.2,0.4,0.6))
 
 } )
+
+test_that("mgsa() with character,MgsaSets signature works with explict multiple p", {
+
+  mgsa.simple <- new( "MgsaSets", sets=test.sets,
+                      itemAnnotations = test.item_anno,
+                      setAnnotations = test.set_anno )
+
+  mgsa.result <- mgsa( test.sets[[1]], mgsa.simple, debug=0, p = c(0.2,0.4,0.6) )
+  expect_is( mgsa.result, 'MgsaMcmcResults' )
+  expect_equal( pPost(mgsa.result)$value, c(0.2,0.4,0.6))
+
+} )


### PR DESCRIPTION
p parameter cannot be set for the function with "character, MgsaSets" signature. See https://github.com/sba1/mgsa-bioc/issues/7#issuecomment-291104620 and https://github.com/sba1/mgsa-bioc/issues/7 for more details.